### PR TITLE
Feat: CSS references

### DIFF
--- a/src/components/code/box.tsx
+++ b/src/components/code/box.tsx
@@ -4,6 +4,7 @@ import { CodeDescBox } from "./desc/box";
 import { CodeOverviewBox } from "./overview/box";
 import { CodeTextBoxClient } from "./text/box-client";
 import { CodeTextBoxServer } from "./text/box-server";
+import { CodeSource } from "./source";
 
 const column = "flex-1 lt960:w-full lt960:flex-none";
 const desc = "pl-72 lt1280:pl-36 lt960:pl-0 lt960:pt-36";
@@ -19,6 +20,8 @@ export function CodeBox(props: { feature: Feature }): ReactElement {
         <Suspense fallback={<CodeTextBoxServer feature={feature} />}>
           <CodeTextBoxClient feature={feature} />
         </Suspense>
+        <div className="mt-36" />
+        <CodeSource feature={feature} />
       </div>
       <div className={`${column} ${desc}`}>
         <CodeDescBox feature={feature} />

--- a/src/components/code/source.tsx
+++ b/src/components/code/source.tsx
@@ -1,0 +1,28 @@
+import { Feature } from "features";
+
+interface Props {
+  feature: Feature;
+}
+
+export function CodeSource({ feature }: Props) {
+  const [attribute, value] = feature.css.split(": ");
+
+  if (!attribute || !value)
+    throw new Error(`unexpected syntax: ${feature.css}`);
+
+  const label = `${feature.name} (${feature.code})`;
+
+  return (
+    <>
+      <div className="mb-18">
+        To use <strong className="font-semibold">{label}</strong> in CSS:
+      </div>
+      <div className="p-24 lt960:p-18 bg-EDF relative shadow-E2E rounded">
+        <code>
+          <span className="text-718">{attribute}: </span>
+          <span className="text-2D3">{value}</span>
+        </code>
+      </div>
+    </>
+  );
+}

--- a/src/components/code/source.tsx
+++ b/src/components/code/source.tsx
@@ -1,28 +1,22 @@
 import { Feature } from "features";
+import { ReactElement } from "react";
 
-interface Props {
-  feature: Feature;
-}
+export function CodeSource(props: { feature: Feature }): ReactElement {
+  const { feature } = props;
 
-export function CodeSource({ feature }: Props) {
-  const [attribute, value] = feature.css.split(": ");
-
-  if (!attribute || !value)
-    throw new Error(`unexpected syntax: ${feature.css}`);
-
-  const label = `${feature.name} (${feature.code})`;
+  const { property, value } = feature.css;
 
   return (
-    <>
-      <div className="mb-18">
-        To use <strong className="font-semibold">{label}</strong> in CSS:
+    <div>
+      <div className="text-15 leading-24 uppercase font-semibold text-718">
+        To enable in css:
       </div>
-      <div className="p-24 lt960:p-18 bg-EDF relative shadow-E2E rounded">
+      <div className="p-24 mt-18 bg-F7F">
         <code>
-          <span className="text-718">{attribute}: </span>
-          <span className="text-2D3">{value}</span>
+          <span className="text-718">{property}: </span>
+          <span className="text-2D3">{value};</span>
         </code>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/code/text/box-base.tsx
+++ b/src/components/code/text/box-base.tsx
@@ -26,7 +26,7 @@ export function CodeTextBoxBase(props: {
 
   return (
     <div className="font-semibold text-2D3">
-      <div className={`${feature.default ? "text-CBD" : ""}  ${""}`}>
+      <div className={`${feature.default ? "text-718" : ""}  ${""}`}>
         <CodeTextLabel id="text-on">
           <span>with “{feature.name}” </span>
           <span>{feature.default ? "disabled" : "enabled"}:</span>
@@ -35,7 +35,7 @@ export function CodeTextBoxBase(props: {
           <CodeTextInput id="text-on" {...input} />
         </div>
       </div>
-      <div className={`${feature.default ? "" : "text-CBD"} mt-36`}>
+      <div className={`${feature.default ? "" : "text-718"} mt-36`}>
         <CodeTextLabel id="text-off">typeface default:</CodeTextLabel>
         <div style={{ fontFeatureSettings: feature.required }}>
           <CodeTextInput id="text-off" {...input} />

--- a/src/components/side/feature/item.tsx
+++ b/src/components/side/feature/item.tsx
@@ -23,7 +23,7 @@ function Name(props: { feature: Feature }): ReactElement {
   return (
     <span className="block">
       <span className="block text-18">{feature.name}</span>
-      <span className="block text-15 truncate text-A0A">
+      <span className="block text-15 truncate text-718">
         {feature.fonts.join(", ")}
       </span>
     </span>

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,6 +1,20 @@
 export interface Feature {
+  /**
+   * The standard code, i.e., in communication
+   */
   code: string;
-  patchedCode?: string; // the real code that get applied, like "clig" for "rand"
+  /**
+   * The real code that get applied, like "calt" for "rand"
+   */
+  patchedCode?: string;
+  /**
+   * The recommended CSS usage,
+   * e.g., with dedicated properties like "font-variant-numeric"
+   */
+  css: {
+    property: string;
+    value: string;
+  };
   name: string;
   family_code?: string;
   family_name?: string;
@@ -12,7 +26,6 @@ export interface Feature {
   type: "digit" | "letter";
   default?: boolean;
   required?: string;
-  css: string;
 }
 
 export const featureMap: { [code: string]: Feature | undefined } = {
@@ -28,7 +41,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures",
     ],
     type: "digit",
-    css: "font-variant-numeric: tabular-nums;",
+    css: {
+      property: "font-variant-numeric",
+      value: "tabular-nums",
+    },
   },
   pnum: {
     code: "pnum",
@@ -42,7 +58,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures",
     ],
     type: "digit",
-    css: "font-variant-numeric: proportional-nums;",
+    css: {
+      property: "font-variant-numeric",
+      value: "proportional-nums",
+    },
   },
   onum: {
     code: "onum",
@@ -58,7 +77,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://practicaltypography.com/alternate-figures.html#oldstyle-figures",
     ],
     type: "digit",
-    css: "font-variant-numeric: oldstyle-nums;",
+    css: {
+      property: "font-variant-numeric",
+      value: "oldstyle-nums",
+    },
   },
   lnum: {
     code: "lnum",
@@ -72,7 +94,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/lining-figures",
     ],
     type: "digit",
-    css: "font-variant-numeric: lining-nums;",
+    css: {
+      property: "font-variant-numeric",
+      value: "lining-nums",
+    },
   },
   ordn: {
     code: "ordn",
@@ -87,7 +112,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://practicaltypography.com/ordinals.html",
     ],
     type: "digit",
-    css: "font-variant-numeric: ordinal;",
+    css: {
+      property: "font-variant-numeric",
+      value: "ordinal",
+    },
   },
   frac: {
     code: "frac",
@@ -101,7 +129,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/fractions",
     ],
     type: "digit",
-    css: "font-variant-numeric: diagonal-fractions;",
+    css: {
+      property: "font-variant-numeric",
+      value: "diagonal-fractions",
+    },
   },
   zero: {
     code: "zero",
@@ -113,7 +144,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     related: [],
     references: [],
     type: "digit",
-    css: "font-variant-numeric: slashed-zero;",
+    css: {
+      property: "font-variant-numeric",
+      value: "slashed-zero",
+    },
   },
   liga: {
     code: "liga",
@@ -129,7 +163,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     ],
     type: "letter",
     default: true,
-    css: "font-variant-ligatures: common-ligatures;",
+    css: {
+      property: "font-variant-ligatures",
+      value: "common-ligatures",
+    },
   },
   calt: {
     code: "calt",
@@ -142,7 +179,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     default: true,
-    css: "font-variant-ligatures: contextual;",
+    css: {
+      property: "font-variant-ligatures",
+      value: "contextual",
+    },
   },
   hist: {
     code: "hist",
@@ -157,7 +197,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/Long_s",
     ],
     type: "letter",
-    css: 'font-feature-settings: "hist";',
+    css: {
+      property: "font-feature-settings",
+      value: "hist",
+    },
   },
   hlig: {
     code: "hlig",
@@ -170,7 +213,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     required: '"hist"',
-    css: "font-variant-ligatures: historical-ligatures;",
+    css: {
+      property: "font-variant-ligatures",
+      value: "historical-ligatures",
+    },
   },
   dlig: {
     code: "dlig",
@@ -184,7 +230,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/signs-and-symbols/ligatures-2",
     ],
     type: "letter",
-    css: "font-variant-ligatures: discretionary-ligatures;",
+    css: {
+      property: "font-variant-ligatures",
+      value: "discretionary-ligatures",
+    },
   },
   salt: {
     code: "salt",
@@ -200,7 +249,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/I#Forms_and_variants",
     ],
     type: "letter",
-    css: 'font-feature-settings: "salt";',
+    css: {
+      property: "font-feature-settings",
+      value: "salt",
+    },
   },
   swsh: {
     code: "swsh",
@@ -215,7 +267,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/Swash_(typography)",
     ],
     type: "letter",
-    css: 'font-feature-settings: "swsh";',
+    css: {
+      property: "font-feature-settings",
+      value: "swsh",
+    },
   },
   smcp: {
     code: "smcp",
@@ -230,7 +285,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-1/type-anatomy/small-caps",
     ],
     type: "letter",
-    css: "font-variant-caps: small-caps;",
+    css: {
+      property: "font-variant-caps",
+      value: "small-caps",
+    },
   },
   rand: {
     code: "rand",
@@ -244,7 +302,10 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     default: true,
-    css: 'font-feature-settings: "calt"',
+    css: {
+      property: "font-feature-settings",
+      value: "calt",
+    },
   },
 };
 

--- a/src/features.ts
+++ b/src/features.ts
@@ -12,6 +12,7 @@ export interface Feature {
   type: "digit" | "letter";
   default?: boolean;
   required?: string;
+  css: string;
 }
 
 export const featureMap: { [code: string]: Feature | undefined } = {
@@ -27,6 +28,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: tabular-nums;",
   },
   pnum: {
     code: "pnum",
@@ -40,6 +42,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: proportional-nums;",
   },
   onum: {
     code: "onum",
@@ -55,6 +58,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://practicaltypography.com/alternate-figures.html#oldstyle-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: oldstyle-nums;",
   },
   lnum: {
     code: "lnum",
@@ -68,6 +72,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/lining-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: lining-nums;",
   },
   ordn: {
     code: "ordn",
@@ -82,6 +87,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://practicaltypography.com/ordinals.html",
     ],
     type: "digit",
+    css: "font-variant-numeric: ordinal;",
   },
   frac: {
     code: "frac",
@@ -95,6 +101,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/fractions",
     ],
     type: "digit",
+    css: "font-variant-numeric: diagonal-fractions;",
   },
   zero: {
     code: "zero",
@@ -106,6 +113,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     related: [],
     references: [],
     type: "digit",
+    css: "font-variant-numeric: slashed-zero;",
   },
   liga: {
     code: "liga",
@@ -121,6 +129,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     ],
     type: "letter",
     default: true,
+    css: "font-variant-ligatures: common-ligatures;",
   },
   calt: {
     code: "calt",
@@ -133,6 +142,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     default: true,
+    css: "font-variant-ligatures: contextual;",
   },
   hist: {
     code: "hist",
@@ -147,6 +157,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/Long_s",
     ],
     type: "letter",
+    css: 'font-feature-settings: "hist";',
   },
   hlig: {
     code: "hlig",
@@ -159,6 +170,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     required: '"hist"',
+    css: "font-variant-ligatures: historical-ligatures;",
   },
   dlig: {
     code: "dlig",
@@ -172,6 +184,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/signs-and-symbols/ligatures-2",
     ],
     type: "letter",
+    css: "font-variant-ligatures: discretionary-ligatures;",
   },
   salt: {
     code: "salt",
@@ -187,6 +200,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/I#Forms_and_variants",
     ],
     type: "letter",
+    css: 'font-feature-settings: "salt";',
   },
   swsh: {
     code: "swsh",
@@ -201,6 +215,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/Swash_(typography)",
     ],
     type: "letter",
+    css: 'font-feature-settings: "swsh";',
   },
   smcp: {
     code: "smcp",
@@ -215,6 +230,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-1/type-anatomy/small-caps",
     ],
     type: "letter",
+    css: "font-variant-caps: small-caps;",
   },
   rand: {
     code: "rand",
@@ -228,6 +244,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     default: true,
+    css: 'font-feature-settings: "calt"',
   },
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,19 +4,19 @@ const config: Config = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     textColor: {
+      "2D3": "#2D3748",
       "718": "#718096",
       CBD: "#CBD5E0",
       A0A: "#A0AEC0",
-      "2D3": "#2D3748",
       FFF: "#FFF",
     },
     backgroundColor: {
       "718": "#718096",
-      FFF: "#FFF",
-      F7F: "#F7FAFC",
-      EDF: "#EDF2F7",
       "4A5": "#4A5568",
       "2D3": "#2D3748",
+      EDF: "#EDF2F7",
+      F7F: "#F7FAFC",
+      FFF: "#FFF",
     },
     boxShadow: {
       E2E: "0px 0px 8px #E2E8F0",
@@ -83,8 +83,8 @@ const config: Config = {
       1: "1",
     },
     screens: {
-      "lt1280": { "max": "1279px" },
-      "lt960": { "max": "959px" },
+      lt1280: { max: "1279px" },
+      lt960: { max: "959px" },
     },
   },
 };


### PR DESCRIPTION
### Description

Add CSS references with a copy code button for easy use

### Reference

Fixes https://github.com/thien-do/otf/issues/9

### Test

<img width="1280" alt="SCR-20240730-ulzh" src="https://github.com/user-attachments/assets/5b34c48a-49cf-41f6-86b2-9577cb32b108">
<img width="1280" alt="SCR-20240730-umeh" src="https://github.com/user-attachments/assets/da8af076-9e93-4762-9ef1-5b1339a10b5a">
